### PR TITLE
Add checking value returned by pv.get().

### DIFF
--- a/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
@@ -354,15 +354,17 @@ class App:
                 method=1, grouping='svd',
                 delta_opticsparam=[delta_chromx, delta_chromy])
 
-        self.driver.setParam('Log-Mon', 'Calculated SL values.')
-
         for fam in self._SFAMS:
             fam_index = self._SFAMS.index(fam)
             current_sl = self._sfam_sl_rb_pvs[fam].get()
+            if current_sl is None:
+                return
             self._lastcalc_sl[fam_index] = (current_sl +
                                             lastcalc_deltasl[fam_index])
             self.driver.setParam('SL' + fam + '-Mon',
                                  self._lastcalc_sl[fam_index])
+
+        self.driver.setParam('Log-Mon', 'Calculated SL values.')
         self.driver.updatePVs()
 
     def _apply_corr(self):

--- a/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
@@ -386,7 +386,10 @@ class App:
         if (self._status & 0x1) == 0:  # Check connection
             # updates reference
             for fam in self._QFAMS:
-                self._qfam_refkl[fam] = self._qfam_kl_rb_pvs[fam].get()
+                value = self._qfam_kl_rb_pvs[fam].get()
+                if value is None:
+                    return
+                self._qfam_refkl[fam] = value
                 self.driver.setParam('RefKL' + fam + '-Mon',
                                      self._qfam_refkl[fam])
 


### PR DESCRIPTION
This PR just fix a minor bug in as-ap-opticscorr IOCs.
It was triggered when pv.get() returned None value, for instance on disconnected state of MA pvs.
