### PR TITLE
Migrate databases to csdevice

### DIFF
--- a/as-ap-currinfo/as_ap_currinfo/charge/pvs.py
+++ b/as-ap-currinfo/as_ap_currinfo/charge/pvs.py
@@ -2,6 +2,7 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.currinfo import get_charge_database as _get_database
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -12,34 +13,23 @@ _PREFIX = _PREFIX_VACA + _DEVICE
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_pvs_database():
     """Return Soft IOC database."""
-    global _COMMIT_HASH
-    pvs_database = {
-        'Version-Cte':        {'type': 'string', 'value': _COMMIT_HASH},
-        'Charge-Mon':         {'type': 'float', 'value': 0.0, 'prec': 10,
-                               'unit': 'A.h'},
-        'ChargeCalcIntvl-SP': {'type': 'float', 'value': 100.0, 'prec': 1,
-                               'unit': 's'},
-        'ChargeCalcIntvl-RB': {'type': 'float', 'value': 100.0, 'prec': 1,
-                               'unit': 's'},
-    }
+    pvs_database = _get_database()
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _COMMIT_HASH, _PREFIX_VACA, _DEVICE, _PREFIX
     _util.print_ioc_banner(
         ioc_name='si-ap-currinfo-charge',
         db=get_pvs_database(),

--- a/as-ap-currinfo/as_ap_currinfo/current/main.py
+++ b/as-ap-currinfo/as_ap_currinfo/current/main.py
@@ -97,7 +97,7 @@ class App:
         """Write value to reason and let callback update PV database."""
         status = False
         if reason == 'DCCT-Sel':
-            if self._dcctfltcheck_mode == 1:  # DCCTFltCheck Off
+            if self._dcctfltcheck_mode == 0:  # DCCTFltCheck Off
                 self._update_dcct_mode(value)
                 self.driver.setParam('DCCT-Sts', self._dcct_mode)
                 self.driver.updatePVs()
@@ -150,7 +150,7 @@ class App:
 
     def _update_dcctfltcheck_mode(self, value):
         if self._dcctfltcheck_mode != value:
-            if value == 0:
+            if value == 1:  # DCCTFltCheck On
                 self._update_dcct_mode_from_reliablemeas()
             self._dcctfltcheck_mode = value
 
@@ -249,5 +249,5 @@ class App:
         elif '14C4' in pvname:
             self._reliablemeas_14C4_value = value
 
-        if self._dcctfltcheck_mode == 0:  # DCCTFltCheck On
+        if self._dcctfltcheck_mode == 1:  # DCCTFltCheck On
             self._update_dcct_mode_from_reliablemeas()

--- a/as-ap-currinfo/as_ap_currinfo/current/main.py
+++ b/as-ap-currinfo/as_ap_currinfo/current/main.py
@@ -2,6 +2,7 @@
 
 import time as _time
 import epics as _epics
+from siriuspy.csdevice.currinfo import Const as _Const
 import as_ap_currinfo.current.pvs as _pvs
 
 # Coding guidelines:
@@ -63,10 +64,13 @@ class App:
                 _pvs.get_pvs_vaca_prefix()+'SI-14C4:DI-DCCT:ReliableMeas-Mon',
                 callback=self._callback_get_reliablemeas)
 
-            self._dcct_mode = 0
-            self._dcctfltcheck_mode = 0
+            self._dcct_mode = _Const.DCCT.Avg
+            self._dcctfltcheck_mode = _Const.DCCTFltCheck.Off
             self._reliablemeas_13C4_value = 0
             self._reliablemeas_14C4_value = 0
+            self._storedebeam_value = 0
+            self._storedebeam_13C4_value = 0
+            self._storedebeam_14C4_value = 0
             if not self._storedebeam_13C4_pv.connected:
                 self._getebeam13C4cbindex = self._current_13C4_pv.add_callback(
                                         self._callback_get_ebeam_fromcurrent)
@@ -97,7 +101,7 @@ class App:
         """Write value to reason and let callback update PV database."""
         status = False
         if reason == 'DCCT-Sel':
-            if self._dcctfltcheck_mode == 0:  # DCCTFltCheck Off
+            if self._dcctfltcheck_mode == _Const.DCCTFltCheck.Off:
                 self._update_dcct_mode(value)
                 self.driver.setParam('DCCT-Sts', self._dcct_mode)
                 self.driver.updatePVs()
@@ -136,13 +140,13 @@ class App:
         mode = self._dcct_mode
         if (self._reliablemeas_13C4_value == 0
                 and self._reliablemeas_14C4_value == 0):
-            mode = 0
+            mode = _Const.DCCT.Avg
         elif (self._reliablemeas_13C4_value == 0
                 and self._reliablemeas_14C4_value != 0):
-            mode = 1
+            mode = _Const.DCCT.DCCT13C4
         elif (self._reliablemeas_13C4_value != 0
                 and self._reliablemeas_14C4_value == 0):
-            mode = 2
+            mode = _Const.DCCT.DCCT14C4
         if mode != self._dcct_mode:
             self._dcct_mode = mode
             self.driver.setParam('DCCT-Sts', self._dcct_mode)
@@ -150,7 +154,7 @@ class App:
 
     def _update_dcctfltcheck_mode(self, value):
         if self._dcctfltcheck_mode != value:
-            if value == 1:  # DCCTFltCheck On
+            if value == _Const.DCCTFltCheck.On:
                 self._update_dcct_mode_from_reliablemeas()
             self._dcctfltcheck_mode = value
 
@@ -159,12 +163,12 @@ class App:
         if conn:
             self._current_13C4_value = self._current_13C4_pv.value
             if self._current_14C4_pv.connected:
-                mode = 0
+                mode = _Const.DCCT.Avg
             else:
-                mode = 1
+                mode = _Const.DCCT.DCCT13C4
         else:
             if self._current_14C4_pv.connected:
-                mode = 2
+                mode = _Const.DCCT.DCCT14C4
         if mode != self._dcct_mode:
             self._dcct_mode = mode
             self.driver.setParam('DCCT-Sts', self._dcct_mode)
@@ -175,12 +179,12 @@ class App:
         if conn:
             self._current_14C4_value = self._current_14C4_pv.value
             if self._current_13C4_pv.connected:
-                mode = 0
+                mode = _Const.DCCT.Avg
             else:
-                mode = 2
+                mode = _Const.DCCT.DCCT14C4
         else:
             if self._current_13C4_pv.connected:
-                mode = 1
+                mode = _Const.DCCT.DCCT13C4
         if mode != self._dcct_mode:
             self._dcct_mode = mode
             self.driver.setParam('DCCT-Sts', self._dcct_mode)
@@ -192,16 +196,16 @@ class App:
         elif '14C4' in pvname:
             self._current_14C4_value = value
 
-        if self._dcct_mode == 0:  # Avg
+        if self._dcct_mode == _Const.DCCT.Avg:
             if (self._current_13C4_value is not None and
                     self._current_14C4_value is not None):
                 self._current_value = (self._current_13C4_value +
                                        self._current_14C4_value)/2
             else:
                 self._current_value = None
-        elif self._dcct_mode == 1:  # 13C4
+        elif self._dcct_mode == _Const.DCCT.DCCT13C4:
                 self._current_value = self._current_13C4_value
-        elif self._dcct_mode == 2:  # 14C4
+        elif self._dcct_mode == _Const.DCCT.DCCT14C4:
             self._current_value = self._current_14C4_value
         self.driver.setParam('Current-Mon', self._current_value)
         self.driver.updatePVs()
@@ -226,12 +230,12 @@ class App:
         elif '14C4' in pvname:
             self._storedebeam_14C4_value = value
 
-        elif self._dcct_mode == 0:  # Avg
+        elif self._dcct_mode == _Const.DCCT.Avg:
             self._storedebeam_value = (self._storedebeam_13C4_value and
                                        self._storedebeam_14C4_value)
-        elif self._dcct_mode == 1:  # 13C4
+        elif self._dcct_mode == _Const.DCCT.DCCT13C4:
             self._storedebeam_value = self._storedebeam_13C4_value
-        elif self._dcct_mode == 2:  # 14C4
+        elif self._dcct_mode == _Const.DCCT.DCCT14C4:
             self._storedebeam_value = self._storedebeam_14C4_value
         self.driver.setParam('StoredEBeam-Mon', self._storedebeam_value)
         self.driver.updatePVs()
@@ -249,5 +253,5 @@ class App:
         elif '14C4' in pvname:
             self._reliablemeas_14C4_value = value
 
-        if self._dcctfltcheck_mode == 1:  # DCCTFltCheck On
+        if self._dcctfltcheck_mode == _Const.DCCTFltCheck.On:
             self._update_dcct_mode_from_reliablemeas()

--- a/as-ap-currinfo/as_ap_currinfo/current/main.py
+++ b/as-ap-currinfo/as_ap_currinfo/current/main.py
@@ -56,17 +56,17 @@ class App:
             self._storedebeam_14C4_pv = _epics.PV(
                 _pvs.get_pvs_vaca_prefix()+'SI-14C4:DI-DCCT:StoredEBeam-Mon',
                 callback=self._callback_get_storedebeam)
-            self._hwflt_13C4_pv = _epics.PV(
-                _pvs.get_pvs_vaca_prefix()+'SI-13C4:DI-DCCT:HwFlt-Mon',
-                callback=self._callback_get_hwflt)
-            self._hwflt_14C4_pv = _epics.PV(
-                _pvs.get_pvs_vaca_prefix()+'SI-14C4:DI-DCCT:HwFlt-Mon',
-                callback=self._callback_get_hwflt)
+            self._reliablemeas_13C4_pv = _epics.PV(
+                _pvs.get_pvs_vaca_prefix()+'SI-13C4:DI-DCCT:ReliableMeas-Mon',
+                callback=self._callback_get_reliablemeas)
+            self._reliablemeas_14C4_pv = _epics.PV(
+                _pvs.get_pvs_vaca_prefix()+'SI-14C4:DI-DCCT:ReliableMeas-Mon',
+                callback=self._callback_get_reliablemeas)
 
             self._dcct_mode = 0
             self._dcctfltcheck_mode = 0
-            self._hwflt_13C4_value = 0
-            self._hwflt_14C4_value = 0
+            self._reliablemeas_13C4_value = 0
+            self._reliablemeas_14C4_value = 0
             if not self._storedebeam_13C4_pv.connected:
                 self._getebeam13C4cbindex = self._current_13C4_pv.add_callback(
                                         self._callback_get_ebeam_fromcurrent)
@@ -109,7 +109,7 @@ class App:
             status = True
         return status
 
-    # BO-AP-CurrInfo Modules
+    # BO-AP-CurrInfo Methods
 
     def _callback_get_current_bo(self, value, **kws):
         self.driver.setParam('Current-Mon', value)
@@ -126,19 +126,22 @@ class App:
             self.driver.setParam('StoredEBeam-Mon', 0)
         self.driver.updatePVs()
 
-    # SI-AP-CurrInfo Modules
+    # SI-AP-CurrInfo Methods
 
     def _update_dcct_mode(self, value):
         if self._dcct_mode != value:
             self._dcct_mode = value
 
-    def _update_dcct_mode_fromhwflt(self):
+    def _update_dcct_mode_from_reliablemeas(self):
         mode = self._dcct_mode
-        if self._hwflt_13C4_value == 0 and self._hwflt_14C4_value == 0:
+        if (self._reliablemeas_13C4_value == 0
+                and self._reliablemeas_14C4_value == 0):
             mode = 0
-        elif self._hwflt_13C4_value == 0 and self._hwflt_14C4_value != 0:
+        elif (self._reliablemeas_13C4_value == 0
+                and self._reliablemeas_14C4_value != 0):
             mode = 1
-        elif self._hwflt_13C4_value != 0 and self._hwflt_14C4_value == 0:
+        elif (self._reliablemeas_13C4_value != 0
+                and self._reliablemeas_14C4_value == 0):
             mode = 2
         if mode != self._dcct_mode:
             self._dcct_mode = mode
@@ -148,7 +151,7 @@ class App:
     def _update_dcctfltcheck_mode(self, value):
         if self._dcctfltcheck_mode != value:
             if value == 0:
-                self._update_dcct_mode_fromhwflt()
+                self._update_dcct_mode_from_reliablemeas()
             self._dcctfltcheck_mode = value
 
     def _connection_callback_current_DCCT13C4(self, pvname, conn, **kws):
@@ -240,11 +243,11 @@ class App:
             self.driver.setParam('StoredEBeam-Mon', 0)
         self.driver.updatePVs()
 
-    def _callback_get_hwflt(self, pvname, value, **kws):
+    def _callback_get_reliablemeas(self, pvname, value, **kws):
         if '13C4' in pvname:
-            self._hwflt_13C4_value = value
+            self._reliablemeas_13C4_value = value
         elif '14C4' in pvname:
-            self._hwflt_14C4_value = value
+            self._reliablemeas_14C4_value = value
 
         if self._dcctfltcheck_mode == 0:  # DCCTFltCheck On
-            self._update_dcct_mode_fromhwflt()
+            self._update_dcct_mode_from_reliablemeas()

--- a/as-ap-currinfo/as_ap_currinfo/current/pvs.py
+++ b/as-ap-currinfo/as_ap_currinfo/current/pvs.py
@@ -2,6 +2,7 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.currinfo import get_current_database as _get_database
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -21,49 +22,28 @@ def select_ioc(acc):
 
 def get_pvs_section():
     """Return Soft IOC transport line."""
-    global _ACC
     return _ACC
 
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_pvs_database():
     """Return IOC database."""
-    global _ACC, _COMMIT_HASH
-
-    pvs_database = {
-        'Version-Cte':     {'type': 'string', 'value': _COMMIT_HASH},
-        'Current-Mon':     {'type': 'float', 'value': 0.0, 'prec': 3,
-                            'unit': 'mA'},
-        'StoredEBeam-Mon': {'type': 'enum', 'value': 0,
-                            'enums': ['False', 'True']},
-    }
-
-    if _ACC == 'SI':
-        pvs_database['DCCT-Sel'] = {'type': 'enum', 'value': 0,
-                                    'enums': ['Avg', '13C4', '14C4']}
-        pvs_database['DCCT-Sts'] = {'type': 'enum', 'value': 0,
-                                    'enums': ['Avg', '13C4', '14C4']}
-        pvs_database['DCCTFltCheck-Sel'] = {'type': 'enum', 'value': 1,
-                                            'enums': ['Off', 'On']}
-        pvs_database['DCCTFltCheck-Sts'] = {'type': 'enum', 'value': 1,
-                                            'enums': ['Off', 'On']}
+    pvs_database = _get_database(_ACC)
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _COMMIT_HASH, _PREFIX_VACA, _ACC, _DEVICE, _PREFIX
     _util.print_ioc_banner(
         ioc_name=_ACC.lower()+'-ap-currinfo-current',
         db=get_pvs_database(),

--- a/as-ap-currinfo/as_ap_currinfo/current/pvs.py
+++ b/as-ap-currinfo/as_ap_currinfo/current/pvs.py
@@ -54,10 +54,10 @@ def get_pvs_database():
                                     'enums': ['Avg', '13C4', '14C4']}
         pvs_database['DCCT-Sts'] = {'type': 'enum', 'value': 0,
                                     'enums': ['Avg', '13C4', '14C4']}
-        pvs_database['DCCTFltCheck-Sel'] = {'type': 'enum', 'value': 0,
-                                            'enums': ['On', 'Off']}
-        pvs_database['DCCTFltCheck-Sts'] = {'type': 'enum', 'value': 0,
-                                            'enums': ['On', 'Off']}
+        pvs_database['DCCTFltCheck-Sel'] = {'type': 'enum', 'value': 1,
+                                            'enums': ['Off', 'On']}
+        pvs_database['DCCTFltCheck-Sts'] = {'type': 'enum', 'value': 1,
+                                            'enums': ['Off', 'On']}
     return pvs_database
 
 

--- a/as-ap-currinfo/as_ap_currinfo/lifetime/main.py
+++ b/as-ap-currinfo/as_ap_currinfo/lifetime/main.py
@@ -4,6 +4,7 @@ import time as _time
 import numpy as _numpy
 import epics as _epics
 import siriuspy.epics as _siriuspy_epics
+from siriuspy.csdevice.currinfo import Const as _Const
 import as_ap_currinfo.lifetime.pvs as _pvs
 
 # Coding guidelines:
@@ -44,7 +45,7 @@ class App:
 
         self._lifetime = 0
         self._rstbuff_cmd_count = 0
-        self._buffautorst_mode = 1
+        self._buffautorst_mode = _Const.BuffAutoRst.DCurrCheck
         if self._injstate_pv.connected:
             self._is_injecting = self._injstate_pv.value
             self._changeinjstate_timestamp = self._injstate_pv.timestamp
@@ -143,7 +144,7 @@ class App:
 
         acquireflag = self._current_buffer.acquire()
         if acquireflag:
-            if self._buffautorst_mode != 2:
+            if self._buffautorst_mode != _Const.BuffAutoRst.Off:
                 self._buffautorst_check()
 
             # Check min number of points in buffer to calculate lifetime
@@ -168,7 +169,7 @@ class App:
         times the dcct fluctuation/resolution.
         """
         [timestamp, value] = self._current_buffer.serie
-        if self._buffautorst_mode == 0:
+        if self._buffautorst_mode == _Const.BuffAutoRst.PVsTrig:
             if (self._storedebeam_pv.connected and
                     self._storedebeam_pv.value == 0):
                 self._current_buffer.clearserie()
@@ -178,7 +179,7 @@ class App:
                   (len(value) >= 2 and
                    (abs(value[-1] - value[-2]) > 0.1))):
                 self._current_buffer.clearserie()
-        elif self._buffautorst_mode == 1:
+        elif self._buffautorst_mode == _Const.BuffAutoRst.DCurrCheck:
             if (len(value) >= 2 and
                     abs(value[-1] - value[-2]) > 100*self._dcurrfactor):
                 self._current_buffer.clearserie()

--- a/as-ap-currinfo/as_ap_currinfo/lifetime/pvs.py
+++ b/as-ap-currinfo/as_ap_currinfo/lifetime/pvs.py
@@ -2,6 +2,7 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.currinfo import get_lifetime_database as _get_database
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -21,50 +22,28 @@ def select_ioc(acc):
 
 def get_pvs_section():
     """Return Soft IOC transport line."""
-    global _ACC
     return _ACC
 
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_pvs_database():
     """Return IOC database."""
-    pvs_database = {
-        'Version-Cte':     {'type': 'string', 'value': _COMMIT_HASH},
-        'Lifetime-Mon':    {'type': 'float', 'value': 0.0, 'prec': 0,
-                            'unit': 's'},
-        'BuffSizeMax-SP':  {'type': 'int', 'lolim': 0, 'hilim': 360000,
-                            'value': 0},
-        'BuffSizeMax-RB':  {'type': 'int', 'value': 0},
-        'BuffSize-Mon':	   {'type': 'int', 'value': 0},
-        'SplIntvl-SP':     {'type': 'int', 'unit': 's',  'lolim': 0,
-                            'hilim': 360000, 'low': 0, 'high': 3600,
-                            'lolo': 0, 'hihi': 3600, 'value': 10},
-        'SplIntvl-RB':	   {'type': 'int', 'value': 10, 'unit': 's'},
-        'BuffRst-Cmd':     {'type': 'int', 'value': 0},
-        'BuffAutoRst-Sel': {'type': 'enum', 'value': 1,
-                            'enums': ['PVsTrig', 'DCurrCheck', 'Off']},
-        'BuffAutoRst-Sts': {'type': 'enum', 'value': 1,
-                            'enums': ['PVsTrig', 'DCurrCheck', 'Off']},
-        'DCurrFactor-Cte': {'type': 'float', 'value': 0.003, 'prec': 2,
-                            'unit': 'mA'}
-    }
+    pvs_database = _get_database()
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _COMMIT_HASH, _PREFIX_VACA, _ACC, _DEVICE, _PREFIX
     _util.print_ioc_banner(
         ioc_name=_ACC.lower()+'-ap-currinfo-lifetime',
         db=get_pvs_database(),

--- a/as-ap-currinfo/tests/charge/test_main.py
+++ b/as-ap-currinfo/tests/charge/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Charge Soft IOC main module."""
 

--- a/as-ap-currinfo/tests/charge/test_pvs.py
+++ b/as-ap-currinfo/tests/charge/test_pvs.py
@@ -19,6 +19,14 @@ valid_interface = (
 class TestASAPCurrInfoChargePvs(unittest.TestCase):
     """Test AS-AP-CurrInfo Charge Soft IOC."""
 
+    def setUp(self):
+        """Setup tests."""
+        csdevice_patcher = mock.patch(
+            "as_ap_currinfo.charge.pvs._get_database",
+            autospec=True)
+        self.addCleanup(csdevice_patcher.stop)
+        self.mock_csdevice = csdevice_patcher.start()
+
     def test_public_interface(self):
         """Test module's public interface."""
         valid = util.check_public_interface_namespace(pvs, valid_interface,
@@ -36,21 +44,8 @@ class TestASAPCurrInfoChargePvs(unittest.TestCase):
 
     def test_get_pvs_database(self):
         """Test get_pvs_database."""
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-
-        # Test IOC interface: pv names
-        self.assertTrue('Version-Cte' in pvs.get_pvs_database())
-        self.assertTrue('Charge-Mon' in pvs.get_pvs_database())
-        self.assertTrue('ChargeCalcIntvl-SP' in pvs.get_pvs_database())
-        self.assertTrue('ChargeCalcIntvl-RB' in pvs.get_pvs_database())
-
-        # Test IOC interface: pvs units
-        self.assertEqual(
-            pvs.get_pvs_database()['Charge-Mon']['unit'], 'A.h')
-        self.assertEqual(
-            pvs.get_pvs_database()['ChargeCalcIntvl-SP']['unit'], 's')
-        self.assertEqual(
-            pvs.get_pvs_database()['ChargeCalcIntvl-RB']['unit'], 's')
+        pvs.get_pvs_database()
+        self.mock_csdevice.assert_called()
 
     @mock.patch("as_ap_currinfo.charge.pvs._util")
     def test_print_banner_and_save_pv_list(self, util):

--- a/as-ap-currinfo/tests/charge/test_pvs.py
+++ b/as-ap-currinfo/tests/charge/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Charge Soft IOC pvs module."""
 

--- a/as-ap-currinfo/tests/current/test_main.py
+++ b/as-ap-currinfo/tests/current/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Current Soft IOC main module."""
 

--- a/as-ap-currinfo/tests/current/test_main.py
+++ b/as-ap-currinfo/tests/current/test_main.py
@@ -5,6 +5,7 @@
 import unittest
 from unittest import mock
 import siriuspy.util as util
+from siriuspy.csdevice.currinfo import Const
 from as_ap_currinfo.current.current import _PCASDriver
 from as_ap_currinfo.current.main import App
 import as_ap_currinfo.current.pvs as pvs
@@ -40,26 +41,29 @@ class TestASAPCurrInfoCurrentMain(unittest.TestCase):
                                                       print_flag=True)
         self.assertTrue(valid)
 
-    def test_write_DCCT_FltCheckOn(self):
-        """Test write DCCT-Sel."""
-        app = App(self.mock_driver)
-        app.write('DCCT-Sel', 0)
-        app.write('DCCT-Sel', 1)
-        app.write('DCCT-Sel', 2)
-        self.mock_driver.setParam.assert_not_called()
-
     def test_write_DCCTFltCheck(self):
         """Test write DCCTFltCheck-Sel."""
         app = App(self.mock_driver)
-        app.write('DCCTFltCheck-Sel', 1)
-        self.mock_driver.setParam.assert_called_with('DCCTFltCheck-Sts', 1)
+        app.write('DCCTFltCheck-Sel', Const.DCCTFltCheck.On)
+        self.mock_driver.setParam.assert_called_with('DCCTFltCheck-Sts',
+                                                     Const.DCCTFltCheck.On)
+
+    def test_write_DCCT_FltCheckOn(self):
+        """Test write DCCT-Sel."""
+        app = App(self.mock_driver)
+        app._dcctfltcheck_mode = Const.DCCTFltCheck.On
+        app.write('DCCT-Sel', Const.DCCT.Avg)
+        app.write('DCCT-Sel', Const.DCCT.DCCT13C4)
+        app.write('DCCT-Sel', Const.DCCT.DCCT14C4)
+        self.mock_driver.setParam.assert_not_called()
 
     def test_write_DCCT_FltCheckOff(self):
         """Test write DCCT-Sel."""
         app = App(self.mock_driver)
-        app.write('DCCTFltCheck-Sel', 1)
-        app.write('DCCT-Sel', 1)
-        self.mock_driver.setParam.assert_called_with('DCCT-Sts', 1)
+        app.write('DCCTFltCheck-Sel', Const.DCCTFltCheck.Off)
+        app.write('DCCT-Sel', Const.DCCT.DCCT13C4)
+        self.mock_driver.setParam.assert_called_with('DCCT-Sts',
+                                                     Const.DCCT.DCCT13C4)
 
 
 if __name__ == "__main__":

--- a/as-ap-currinfo/tests/current/test_pvs.py
+++ b/as-ap-currinfo/tests/current/test_pvs.py
@@ -21,6 +21,14 @@ valid_interface = (
 class TestASAPCurrInfoCurrentPvs(unittest.TestCase):
     """Test AS-AP-CurrInfo Current Soft IOC."""
 
+    def setUp(self):
+        """Setup tests."""
+        csdevice_patcher = mock.patch(
+            "as_ap_currinfo.current.pvs._get_database",
+            autospec=True)
+        self.addCleanup(csdevice_patcher.stop)
+        self.mock_csdevice = csdevice_patcher.start()
+
     def test_public_interface(self):
         """Test module's public interface."""
         valid = util.check_public_interface_namespace(pvs, valid_interface,
@@ -59,30 +67,8 @@ class TestASAPCurrInfoCurrentPvs(unittest.TestCase):
 
     def test_get_pvs_database(self):
         """Test get_pvs_database."""
-
-        # Test IOC interface: pv names
-        pvs.select_ioc('Accelerator')
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-        self.assertTrue('Version-Cte' in pvs.get_pvs_database())
-        self.assertTrue('Current-Mon' in pvs.get_pvs_database())
-        self.assertTrue('StoredEBeam-Mon' in pvs.get_pvs_database())
-
-        pvs.select_ioc('SI')
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-        self.assertTrue('DCCT-Sel' in pvs.get_pvs_database())
-        self.assertTrue('DCCT-Sts' in pvs.get_pvs_database())
-        self.assertTrue('DCCTFltCheck-Sel' in pvs.get_pvs_database())
-        self.assertTrue('DCCTFltCheck-Sts' in pvs.get_pvs_database())
-
-        pvs.select_ioc('BO')
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-        self.assertFalse('DCCT-Sel' in pvs.get_pvs_database())
-        self.assertFalse('DCCT-Sts' in pvs.get_pvs_database())
-        self.assertFalse('DCCTFltCheck-Sel' in pvs.get_pvs_database())
-        self.assertFalse('DCCTFltCheck-Sts' in pvs.get_pvs_database())
-
-        # Test IOC interface: pvs units
-        self.assertEqual(pvs.get_pvs_database()['Current-Mon']['unit'], 'mA')
+        pvs.get_pvs_database()
+        self.mock_csdevice.assert_called()
 
     @mock.patch("as_ap_currinfo.current.pvs._util")
     def test_print_banner_and_save_pv_list(self, util):

--- a/as-ap-currinfo/tests/current/test_pvs.py
+++ b/as-ap-currinfo/tests/current/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Current Soft IOC pvs module."""
 

--- a/as-ap-currinfo/tests/lifetime/test_main.py
+++ b/as-ap-currinfo/tests/lifetime/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Lifetime Soft IOC main module."""
 

--- a/as-ap-currinfo/tests/lifetime/test_pvs.py
+++ b/as-ap-currinfo/tests/lifetime/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-CurrInfo Lifetime Soft IOC pvs module."""
 

--- a/as-ap-currinfo/tests/lifetime/test_pvs.py
+++ b/as-ap-currinfo/tests/lifetime/test_pvs.py
@@ -21,6 +21,14 @@ valid_interface = (
 class TestASAPCurrInfoLifetimePvs(unittest.TestCase):
     """Test AS-AP-CurrInfo Lifetime Soft IOC."""
 
+    def setUp(self):
+        """Setup tests."""
+        csdevice_patcher = mock.patch(
+            "as_ap_currinfo.lifetime.pvs._get_database",
+            autospec=True)
+        self.addCleanup(csdevice_patcher.stop)
+        self.mock_csdevice = csdevice_patcher.start()
+
     def test_public_interface(self):
         """Test module's public interface."""
         valid = util.check_public_interface_namespace(pvs, valid_interface,
@@ -59,31 +67,8 @@ class TestASAPCurrInfoLifetimePvs(unittest.TestCase):
 
     def test_get_pvs_database(self):
         """Test get_pvs_database."""
-        pvs.select_ioc('Accelerator')
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-
-        # Test IOC interface: pv names
-        self.assertTrue('Version-Cte' in pvs.get_pvs_database())
-        self.assertTrue('Lifetime-Mon' in pvs.get_pvs_database())
-        self.assertTrue('BuffSizeMax-SP' in pvs.get_pvs_database())
-        self.assertTrue('BuffSizeMax-RB' in pvs.get_pvs_database())
-        self.assertTrue('BuffSize-Mon' in pvs.get_pvs_database())
-        self.assertTrue('SplIntvl-SP' in pvs.get_pvs_database())
-        self.assertTrue('SplIntvl-RB' in pvs.get_pvs_database())
-        self.assertTrue('BuffRst-Cmd' in pvs.get_pvs_database())
-        self.assertTrue('BuffAutoRst-Sel' in pvs.get_pvs_database())
-        self.assertTrue('BuffAutoRst-Sts' in pvs.get_pvs_database())
-        self.assertTrue('DCurrFactor-Cte' in pvs.get_pvs_database())
-
-        # Test IOC interface: pvs units
-        self.assertEqual(
-            pvs.get_pvs_database()['Lifetime-Mon']['unit'], 's')
-        self.assertEqual(
-            pvs.get_pvs_database()['SplIntvl-SP']['unit'], 's')
-        self.assertEqual(
-            pvs.get_pvs_database()['SplIntvl-RB']['unit'], 's')
-        self.assertEqual(
-            pvs.get_pvs_database()['DCurrFactor-Cte']['unit'], 'mA')
+        pvs.get_pvs_database()
+        self.mock_csdevice.assert_called()
 
     @mock.patch("as_ap_currinfo.lifetime.pvs._util")
     def test_print_banner_and_save_pv_list(self, util):

--- a/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
@@ -40,7 +40,7 @@ class App:
         _pvs.print_banner_and_save_pv_list()
         self._PREFIX_VACA = _pvs.get_pvs_vaca_prefix()
         self._ACC = _pvs.get_pvs_section()
-        self._SFAMS = list(_pvs.get_corr_fams())
+        self._SFAMS = _pvs.get_corr_fams()
 
         self._driver = driver
 
@@ -76,6 +76,8 @@ class App:
                 sfam_focusing.append(fam)
             else:
                 sfam_defocusing.append(fam)
+        sfam_focusing = tuple(sfam_focusing)
+        sfam_defocusing = tuple(sfam_defocusing)
 
         # Initialize correction parameters from local file and configdb
         config_name = _get_config_name(acc=self._ACC.lower(),

--- a/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/chrom/main.py
@@ -40,7 +40,7 @@ class App:
         _pvs.print_banner_and_save_pv_list()
         self._PREFIX_VACA = _pvs.get_pvs_vaca_prefix()
         self._ACC = _pvs.get_pvs_section()
-        self._SFAMS = _pvs.get_corr_fams()
+        self._SFAMS = list(_pvs.get_corr_fams())
 
         self._driver = driver
 

--- a/as-ap-opticscorr/as_ap_opticscorr/chrom/pvs.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/chrom/pvs.py
@@ -2,6 +2,9 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.opticscorr import (
+    Const as _Const,
+    get_chrom_database as _get_database)
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -19,98 +22,40 @@ def select_ioc(acc):
     _DEVICE = _ACC + '-Glob:AP-ChromCorr:'
     _PREFIX = _PREFIX_VACA + _DEVICE
     if _ACC == 'BO':
-        _SFAMS = ['SF', 'SD']
+        _SFAMS = _Const.BO_SFAMS_CHROMCORR
     elif _ACC == 'SI':
-        _SFAMS = ['SFA1', 'SFA2', 'SDA1', 'SDA2', 'SDA3',
-                  'SFB1', 'SFB2', 'SDB1', 'SDB2', 'SDB3',
-                  'SFP1', 'SFP2', 'SDP1', 'SDP2', 'SDP3']
+        _SFAMS = _Const.SI_SFAMS_CHROMCORR
 
 
 def get_pvs_section():
     """Return Soft IOC section/accelerator."""
-    global _ACC
     return _ACC
 
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_corr_fams():
     """Return list of magnet families used on correction."""
-    global _SFAMS
     return _SFAMS
 
 
 def get_pvs_database():
     """Return IOC database."""
-    global _SFAMS, _COMMIT_HASH
-    corrmat_size = len(_SFAMS)*2
-
-    pvs_database = {
-        'Version-Cte':          {'type': 'string', 'value': _COMMIT_HASH,
-                                 'scan': 0.25},
-
-        'Log-Mon':              {'type': 'string', 'value': 'Starting...'},
-
-        'ChromX-SP':            {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 10, 'lolim': -10, 'high': 10,
-                                 'low': -10, 'hihi': 10, 'lolo': -10},
-        'ChromX-RB':            {'type': 'float', 'value': 0, 'prec': 6},
-        'ChromY-SP':            {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 10, 'lolim': -10, 'high': 10,
-                                 'low': -10, 'hihi': 10, 'lolo': -10},
-        'ChromY-RB':            {'type': 'float', 'value': 0, 'prec': 6},
-
-        'ApplyCorr-Cmd':        {'type': 'int', 'value': 0},
-
-        'ConfigName-SP':        {'type': 'string', 'value': ''},
-        'ConfigName-RB':        {'type': 'string', 'value': ''},
-        'RespMat-Mon':          {'type': 'float', 'count': corrmat_size,
-                                 'value': corrmat_size*[0], 'prec': 6, 'unit':
-                                 'Chrom x SFams (Matrix of add method)'},
-        'NominalChrom-Mon':     {'type': 'float', 'count': 2, 'value': 2*[0],
-                                 'prec': 6},
-        'NominalSL-Mon':        {'type': 'float', 'count': len(_SFAMS),
-                                 'value': len(_SFAMS)*[0], 'prec': 6},
-
-        'ConfigMA-Cmd':         {'type': 'int', 'value': 0},
-
-        'Status-Mon':           {'type': 'int', 'value': 0x1f},
-        'Status-Cte':           {'type': 'string', 'count': 5, 'value':
-                                 ('MA Connection', 'MA PwrState', 'MA OpMode',
-                                  'MA CtrlMode', 'Timing Config')},
-    }
-
-    for fam in _SFAMS:
-        pvs_database['SL' + fam + '-Mon'] = {
-            'type': 'float', 'value': 0, 'prec': 4, 'unit': '1/m^2',
-            'lolim': 0, 'hilim': 0, 'low': 0, 'high': 0, 'lolo': 0, 'hihi': 0}
-
-    if _ACC == 'SI':
-        pvs_database['CorrMeth-Sel'] = {'type': 'enum', 'value': 0, 'enums':
-                                        ['Proportional', 'Additional']}
-        pvs_database['CorrMeth-Sts'] = {'type': 'enum', 'value': 0, 'enums':
-                                        ['Proportional', 'Additional']}
-        pvs_database['SyncCorr-Sel'] = {'type': 'enum', 'value': 0,
-                                        'enums': ['Off', 'On']}
-        pvs_database['SyncCorr-Sts'] = {'type': 'enum', 'value': 0,
-                                        'enums': ['Off', 'On']}
-        pvs_database['ConfigTiming-Cmd'] = {'type': 'int', 'value': 0}
+    pvs_database = _get_database(_ACC)
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _COMMIT_HASH, _PREFIX_VACA, _ACC, _DEVICE, _PREFIX
     _util.print_ioc_banner(
         ioc_name=_ACC+'-AP-ChromCorr',
         db=get_pvs_database(),

--- a/as-ap-opticscorr/as_ap_opticscorr/opticscorr_utils.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/opticscorr_utils.py
@@ -37,8 +37,8 @@ class OpticsCorr:
 
     def _set_magnetfams_ordering(self, value):
         """Set magnetfams_ordering_svd property."""
-        if not isinstance(value, list):
-            raise TypeError("Value must be a list.")
+        if not isinstance(value, tuple):
+            raise TypeError("Value must be a tuple.")
         for item in value:
             if not isinstance(item, str):
                 raise TypeError("List elements must be strings.")
@@ -127,8 +127,8 @@ class OpticsCorr:
 
     @magnetfams_focusing.setter
     def magnetfams_focusing(self, value):
-        if not isinstance(value, list):
-            raise TypeError("Value must be a list.")
+        if not isinstance(value, tuple):
+            raise TypeError("Value must be a tuple.")
         for item in value:
             if not isinstance(item, str):
                 raise TypeError("List elements must be strings.")
@@ -139,8 +139,8 @@ class OpticsCorr:
             raise ValueError("Focusing magnet families must be part of the "
                              "'magnetfams_ordering' property!")
 
-        self._magnetfams_focusing = sorted(
-            value, key=lambda x: self.magnetfams_ordering.index(x))
+        self._magnetfams_focusing = tuple(sorted(
+            value, key=lambda x: self.magnetfams_ordering.index(x)))
 
         if self._initialized:
             self._calculate_matrices()
@@ -155,8 +155,8 @@ class OpticsCorr:
 
     @magnetfams_defocusing.setter
     def magnetfams_defocusing(self, value):
-        if not isinstance(value, list):
-            raise TypeError("Value must be a list.")
+        if not isinstance(value, tuple):
+            raise TypeError("Value must be a tuple.")
         for item in value:
             if not isinstance(item, str):
                 raise TypeError("List elements must be strings.")
@@ -167,8 +167,8 @@ class OpticsCorr:
             raise ValueError("Defocusing magnet families must be part of the "
                              "'magnetfams_ordering_svd' property!")
 
-        self._magnetfams_defocusing = sorted(
-            value, key=lambda x: self.magnetfams_ordering.index(x))
+        self._magnetfams_defocusing = tuple(sorted(
+            value, key=lambda x: self.magnetfams_ordering.index(x)))
 
         if self._initialized:
             self._calculate_matrices()

--- a/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
@@ -40,7 +40,7 @@ class App:
         _pvs.print_banner_and_save_pv_list()
         self._PREFIX_VACA = _pvs.get_pvs_vaca_prefix()
         self._ACC = _pvs.get_pvs_section()
-        self._QFAMS = list(_pvs.get_corr_fams())
+        self._QFAMS = _pvs.get_corr_fams()
 
         self._driver = driver
 
@@ -78,6 +78,8 @@ class App:
                 qfam_focusing.append(fam)
             else:
                 qfam_defocusing.append(fam)
+        qfam_focusing = tuple(qfam_focusing)
+        qfam_defocusing = tuple(qfam_defocusing)
 
         # Initialize correction parameters from local file and configdb
         config_name = _get_config_name(acc=self._ACC.lower(),

--- a/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
@@ -40,7 +40,7 @@ class App:
         _pvs.print_banner_and_save_pv_list()
         self._PREFIX_VACA = _pvs.get_pvs_vaca_prefix()
         self._ACC = _pvs.get_pvs_section()
-        self._QFAMS = _pvs.get_corr_fams()
+        self._QFAMS = list(_pvs.get_corr_fams())
 
         self._driver = driver
 

--- a/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/tune/main.py
@@ -4,6 +4,7 @@ import time as _time
 import epics as _epics
 import siriuspy as _siriuspy
 from siriuspy.servconf.conf_service import ConfigService as _ConfigService
+from siriuspy.csdevice.opticscorr import Const as _Const
 from as_ap_opticscorr.opticscorr_utils import (
         OpticsCorr as _OpticsCorr,
         get_config_name as _get_config_name,
@@ -61,13 +62,13 @@ class App:
         self._qfam_kl_rb = len(self._QFAMS)*[0]
 
         if self._ACC.lower() == 'si':
-            self._corr_method = 0
-            self._sync_corr = 0
+            self._corr_method = _Const.CorrMeth.Proportional
+            self._sync_corr = _Const.SyncCorr.Off
             self._config_timing_cmd_count = 0
             self._timing_check_config = 6*[0]
         else:
-            self._corr_method = 1
-            self._sync_corr = 0
+            self._corr_method = _Const.CorrMeth.Additional
+            self._sync_corr = _Const.SyncCorr.Off
 
         # Get focusing and defocusing families
         qfam_focusing = []
@@ -342,7 +343,7 @@ class App:
             return [done, []]
 
     def _calc_deltakl(self):
-        if self._corr_method == 0:
+        if self._corr_method == _Const.CorrMeth.Proportional:
             lastcalc_deltakl = self._opticscorr.calculate_delta_intstrengths(
                 method=0, grouping='2knobs',
                 delta_opticsparam=[self._delta_tunex, self._delta_tuney])
@@ -362,7 +363,8 @@ class App:
         self.driver.updatePVs()
 
     def _apply_corr(self):
-        if ((self._status == _ALLCLR_SYNCOFF and self._sync_corr == 0) or
+        if ((self._status == _ALLCLR_SYNCOFF and
+                self._sync_corr == _Const.SyncCorr.Off) or
                 self._status == _ALLCLR_SYNCON):
             for fam in self._qfam_kl_sp_pvs:
                 fam_index = self._QFAMS.index(fam)
@@ -372,7 +374,7 @@ class App:
             self.driver.setParam('Log-Mon', 'Applied correction.')
             self.driver.updatePVs()
 
-            if self._sync_corr == 1:
+            if self._sync_corr == _Const.SyncCorr.On:
                 self._timing_evg_tunesexttrig_cmd.put(0)
                 self.driver.setParam('Log-Mon', 'Generated trigger.')
                 self.driver.updatePVs()

--- a/as-ap-opticscorr/as_ap_opticscorr/tune/pvs.py
+++ b/as-ap-opticscorr/as_ap_opticscorr/tune/pvs.py
@@ -2,6 +2,9 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.opticscorr import (
+    Const as _Const,
+    get_tune_database as _get_database)
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -19,112 +22,40 @@ def select_ioc(acc):
     _DEVICE = _ACC + '-Glob:AP-TuneCorr:'
     _PREFIX = _PREFIX_VACA + _DEVICE
     if _ACC == 'BO':
-        _QFAMS = ['QF', 'QD']
+        _QFAMS = _Const.BO_QFAMS_TUNECORR
     elif _ACC == 'SI':
-        _QFAMS = ['QFA', 'QFB', 'QFP',
-                  'QDA', 'QDB1', 'QDB2', 'QDP1', 'QDP2']
+        _QFAMS = _Const.SI_QFAMS_TUNECORR
 
 
 def get_pvs_section():
     """Return Soft IOC section/accelerator."""
-    global _ACC
     return _ACC
 
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_corr_fams():
     """Return list of magnet families used on correction."""
-    global _QFAMS
     return _QFAMS
 
 
 def get_pvs_database():
     """Return IOC database."""
-    global _COMMIT_HASH, _ACC, _QFAMS
-    corrmat_size = len(_QFAMS)*2
-
-    pvs_database = {
-        'Version-Cte':          {'type': 'string', 'value': _COMMIT_HASH},
-
-        'Log-Mon':              {'type': 'string', 'value': 'Starting...'},
-
-        'DeltaTuneX-SP':        {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 1, 'lolim': -1, 'high': 1, 'low': -1,
-                                 'hihi': 1, 'lolo': -1},
-        'DeltaTuneX-RB':        {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 1, 'lolim': -1, 'high': 1, 'low': -1,
-                                 'hihi': 1, 'lolo': -1},
-        'DeltaTuneY-SP':        {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 1, 'lolim': -1, 'high': 1, 'low': -1,
-                                 'hihi': 1, 'lolo': -1},
-        'DeltaTuneY-RB':        {'type': 'float', 'value': 0, 'prec': 6,
-                                 'hilim': 1, 'lolim': -1, 'high': 1, 'low': -1,
-                                 'hihi': 1, 'lolo': -1},
-
-        'ApplyCorr-Cmd':        {'type': 'int', 'value': 0},
-
-        'ConfigName-SP':        {'type': 'string', 'value': ''},
-        'ConfigName-RB':        {'type': 'string', 'value': ''},
-        'RespMat-Mon':          {'type': 'float', 'count': corrmat_size,
-                                 'value': corrmat_size*[0], 'prec': 6, 'unit':
-                                 'Tune x QFams (Nominal Response Matrix)'},
-        'NominalKL-Mon':        {'type': 'float', 'count': len(_QFAMS),
-                                 'value': len(_QFAMS)*[0], 'prec': 6},
-
-        'CorrFactor-SP':        {'type': 'float', 'value': 0, 'unit': '%',
-                                 'prec': 1, 'hilim': 1000, 'lolim': -1000,
-                                 'high': 1000, 'low': -1000, 'hihi': 1000,
-                                 'lolo': -1000},
-        'CorrFactor-RB':        {'type': 'float', 'value': 0, 'unit': '%',
-                                 'prec': 1, 'hilim': 1000, 'lolim': -1000,
-                                 'high': 1000, 'low': -1000, 'hihi': 1000,
-                                 'lolo': -1000},
-
-        'ConfigMA-Cmd':         {'type': 'int', 'value': 0},
-
-        'SetNewRefKL-Cmd':      {'type': 'int', 'value': 0},
-
-        'Status-Mon':           {'type': 'int', 'value': 0x1f},
-        'Status-Cte':           {'type': 'string', 'count': 5, 'value':
-                                 ('MA Connection', 'MA PwrState', 'MA OpMode',
-                                  'MA CtrlMode', 'Timing Config')},
-    }
-
-    for fam in _QFAMS:
-        pvs_database['RefKL' + fam + '-Mon'] = {'type': 'float', 'value': 0,
-                                                'prec': 6, 'unit': '1/m'}
-
-        pvs_database['DeltaKL' + fam + '-Mon'] = {
-            'type': 'float', 'value': 0, 'prec': 6, 'unit': '1/m',
-            'lolim': 0, 'hilim': 0, 'low': 0, 'high': 0, 'lolo': 0, 'hihi': 0}
-
-    if _ACC == 'SI':
-        pvs_database['CorrMeth-Sel'] = {'type': 'enum', 'value': 0, 'enums':
-                                        ['Proportional', 'Additional']}
-        pvs_database['CorrMeth-Sts'] = {'type': 'enum', 'value': 0, 'enums':
-                                        ['Proportional', 'Additional']}
-        pvs_database['SyncCorr-Sel'] = {'type': 'enum', 'value': 0,
-                                        'enums': ['Off', 'On']}
-        pvs_database['SyncCorr-Sts'] = {'type': 'enum', 'value': 0,
-                                        'enums': ['Off', 'On']}
-        pvs_database['ConfigTiming-Cmd'] = {'type': 'int', 'value': 0}
+    pvs_database = _get_database(_ACC)
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _COMMIT_HASH, _PREFIX_VACA, _ACC, _PREFIX, _DEVICE
     _util.print_ioc_banner(
         ioc_name=_ACC+'-AP-TuneCorr',
         db=get_pvs_database(),

--- a/as-ap-opticscorr/tests/chrom/test_main.py
+++ b/as-ap-opticscorr/tests/chrom/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-ChromCorr Soft IOC main module."""
 

--- a/as-ap-opticscorr/tests/chrom/test_pvs.py
+++ b/as-ap-opticscorr/tests/chrom/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-ChromCorr Soft IOC pvs module."""
 

--- a/as-ap-opticscorr/tests/chrom/test_pvs.py
+++ b/as-ap-opticscorr/tests/chrom/test_pvs.py
@@ -4,7 +4,8 @@
 
 import unittest
 from unittest import mock
-import siriuspy.util as util
+from siriuspy import util
+from siriuspy.csdevice.opticscorr import Const
 import as_ap_opticscorr.chrom.pvs as pvs
 
 
@@ -24,10 +25,13 @@ class TestASAPOpticsCorrChromPvs(unittest.TestCase):
 
     def setUp(self):
         """Setup tests."""
-        self.si_sfams = ['SFA1', 'SFA2', 'SDA1', 'SDA2', 'SDA3',
-                         'SFB1', 'SFB2', 'SDB1', 'SDB2', 'SDB3',
-                         'SFP1', 'SFP2', 'SDP1', 'SDP2', 'SDP3']
-        self.bo_sfams = ['SF', 'SD']
+        self.si_sfams = Const.SI_SFAMS_CHROMCORR
+        self.bo_sfams = Const.BO_SFAMS_CHROMCORR
+        csdevice_patcher = mock.patch(
+            "as_ap_opticscorr.chrom.pvs._get_database",
+            autospec=True)
+        self.addCleanup(csdevice_patcher.stop)
+        self.mock_csdevice = csdevice_patcher.start()
 
     def test_public_interface(self):
         """Test module's public interface."""
@@ -83,40 +87,8 @@ class TestASAPOpticsCorrChromPvs(unittest.TestCase):
 
     def test_get_pvs_database(self):
         """Test get_pvs_database."""
-        for accelerator in ['SI', 'BO']:
-            if accelerator == 'SI':
-                sfams = self.si_sfams
-            elif accelerator == 'BO':
-                sfams = self.bo_sfams
-            pvs.select_ioc(accelerator)
-            db = pvs.get_pvs_database()
-            self.assertIsInstance(db, dict)
-            self.assertTrue('Version-Cte' in db)
-            self.assertTrue('Log-Mon' in db)
-            self.assertTrue('ChromX-SP' in db)
-            self.assertTrue('ChromX-RB' in db)
-            self.assertTrue('ChromY-SP' in db)
-            self.assertTrue('ChromY-RB' in db)
-            self.assertTrue('ApplyCorr-Cmd' in db)
-            self.assertTrue('ConfigName-SP' in db)
-            self.assertTrue('ConfigName-RB' in db)
-            self.assertTrue('RespMat-Mon' in db)
-            self.assertTrue('NominalChrom-Mon' in db)
-            self.assertTrue('NominalSL-Mon' in db)
-            self.assertTrue('ConfigMA-Cmd' in db)
-            self.assertTrue('Status-Mon' in db)
-            self.assertTrue('StatusLabels-Cte' in db)
-
-            for fam in sfams:
-                self.assertTrue('SL' + fam + '-Mon' in db)
-                self.assertEqual(db['SL' + fam + '-Mon']['unit'],
-                                 '1/m^2')
-            if accelerator == 'SI':
-                self.assertTrue('CorrMeth-Sel' in db)
-                self.assertTrue('CorrMeth-Sts' in db)
-                self.assertTrue('SyncCorr-Sel' in db)
-                self.assertTrue('SyncCorr-Sts' in db)
-                self.assertTrue('ConfigTiming-Cmd' in db)
+        pvs.get_pvs_database()
+        self.mock_csdevice.assert_called()
 
     @mock.patch("as_ap_opticscorr.chrom.pvs._util")
     def test_print_banner_and_save_pv_list(self, util):

--- a/as-ap-opticscorr/tests/chrom/test_pvs.py
+++ b/as-ap-opticscorr/tests/chrom/test_pvs.py
@@ -70,13 +70,13 @@ class TestASAPOpticsCorrChromPvs(unittest.TestCase):
     def test_get_corr_fams(self):
         """Test get_corr_fams."""
         pvs.select_ioc('SI')
-        self.assertIsInstance(pvs.get_corr_fams(), list)
+        self.assertIsInstance(pvs.get_corr_fams(), tuple)
         self.assertEqual(len(pvs.get_corr_fams()), 15)
         for fam in self.si_sfams:
             self.assertIn(fam, pvs.get_corr_fams())
 
         pvs.select_ioc('BO')
-        self.assertIsInstance(pvs.get_corr_fams(), list)
+        self.assertIsInstance(pvs.get_corr_fams(), tuple)
         self.assertEqual(len(pvs.get_corr_fams()), 2)
         for fam in self.bo_sfams:
             self.assertIn(fam, pvs.get_corr_fams())
@@ -105,7 +105,7 @@ class TestASAPOpticsCorrChromPvs(unittest.TestCase):
             self.assertTrue('NominalSL-Mon' in db)
             self.assertTrue('ConfigMA-Cmd' in db)
             self.assertTrue('Status-Mon' in db)
-            self.assertTrue('Status-Cte' in db)
+            self.assertTrue('StatusLabels-Cte' in db)
 
             for fam in sfams:
                 self.assertTrue('SL' + fam + '-Mon' in db)

--- a/as-ap-opticscorr/tests/test_opticscorr_utils.py
+++ b/as-ap-opticscorr/tests/test_opticscorr_utils.py
@@ -41,11 +41,11 @@ class TestOpticsCorr(unittest.TestCase):
     def setUp(self):
         """Setup tests."""
         # Attributs fot simulating normal operation
-        self.magnetfams_ordering_ok = [
-            'QFA', 'QFB', 'QFP', 'QDA', 'QDB1', 'QDB2', 'QDP1', 'QDP2']
-        self.magnetfams_focusing_ok = ['QFA', 'QFB', 'QFP']
-        self.magnetfams_defocusing_ok = [
-            'QDA', 'QDB1', 'QDB2', 'QDP1', 'QDP2']
+        self.magnetfams_ordering_ok = (
+            'QFA', 'QFB', 'QFP', 'QDA', 'QDB1', 'QDB2', 'QDP1', 'QDP2')
+        self.magnetfams_focusing_ok = ('QFA', 'QFB', 'QFP')
+        self.magnetfams_defocusing_ok = (
+            'QDA', 'QDB1', 'QDB2', 'QDP1', 'QDP2')
         self.nominal_matrix_ok = [2.7280, 8.5894, 4.2995, 0.5377,
                                   1.0906, 2.0004, 0.5460, 1.0012,
                                   -1.3651, -3.5532, -1.7657, -2.3652,
@@ -55,9 +55,9 @@ class TestOpticsCorr(unittest.TestCase):
         self.nominal_opticsparam_ok = [0.0, 0.0]
 
         # Attributes to simulate type errors
-        self.magnetfams_ordering_error1 = [1, 2, 3, 4]
-        self.magnetfams_focusing_error1 = [1, 2]
-        self.magnetfams_defocusing_error1 = [3, 4]
+        self.magnetfams_ordering_error1 = (1, 2, 3, 4)
+        self.magnetfams_focusing_error1 = (1, 2)
+        self.magnetfams_defocusing_error1 = (3, 4)
         self.nominal_matrix_error1 = [
             '2.7280', '8.5894', '0.5460', '1.0012',
             '-1.3651', '-3.5532', '-2.3601', '-0.9839']
@@ -66,16 +66,16 @@ class TestOpticsCorr(unittest.TestCase):
         self.nominal_opticsparam_error1 = ['0.0', '0.0']
 
         # Attributes to simulate matrix invertion errors
-        self.magnetfams_ordering_error2 = ['QF', 'QD']
-        self.magnetfams_focusing_error2 = ['QF']
-        self.magnetfams_defocusing_error2 = ['QD']
+        self.magnetfams_ordering_error2 = ('QF', 'QD')
+        self.magnetfams_focusing_error2 = ('QF')
+        self.magnetfams_defocusing_error2 = ('QD')
         self.nominal_matrix_error2 = [0.0, 2, 0.1, 4]
         self.nominal_intstrengths_error2 = [0.3, -1.5]
 
         # Attributes to simulate value errors
-        self.magnetfams_ordering_error3 = []
-        self.magnetfams_focusing_error3 = []
-        self.magnetfams_defocusing_error3 = []
+        self.magnetfams_ordering_error3 = ()
+        self.magnetfams_focusing_error3 = ()
+        self.magnetfams_defocusing_error3 = ()
         self.nominal_matrix_error3 = [2.7280, 8.5894, 4.2995, 0.5377,
                                       1.0906, 2.0004, 0.5460, 1.0012,
                                       -1.3651, -3.5532, -1.7657, -2.3652,
@@ -83,8 +83,8 @@ class TestOpticsCorr(unittest.TestCase):
         self.nominal_opticsparam_error3 = [0.0, 0.0, 0.0]
 
         # Attributes to test correction with some families, not all
-        self.magnetfams_focusing_somefams = ['QFA', 'QFB']
-        self.magnetfams_defocusing_somefams = ['QDA', 'QDB2', 'QDB1']
+        self.magnetfams_focusing_somefams = ('QFA', 'QFB')
+        self.magnetfams_defocusing_somefams = ('QDA', 'QDB2', 'QDB1')
 
     def test_public_interface(self):
         """Test module's public interface."""
@@ -219,7 +219,7 @@ class TestOpticsCorr(unittest.TestCase):
                                      self.magnetfams_defocusing_ok)
 
         propty = self.opticscorr.magnetfams_ordering
-        self.assertIsInstance(propty, list)
+        self.assertIsInstance(propty, tuple)
         for item in propty:
             self.assertIsInstance(item, str)
         self.assertGreaterEqual(len(propty), 1)
@@ -234,7 +234,7 @@ class TestOpticsCorr(unittest.TestCase):
                                      self.magnetfams_defocusing_ok)
 
         propty = self.opticscorr.magnetfams_focusing
-        self.assertIsInstance(propty, list)
+        self.assertIsInstance(propty, tuple)
         for item in propty:
             self.assertIsInstance(item, str)
         self.assertGreaterEqual(len(propty), 1)
@@ -249,7 +249,7 @@ class TestOpticsCorr(unittest.TestCase):
                                      self.magnetfams_defocusing_ok)
 
         propty = self.opticscorr.magnetfams_defocusing
-        self.assertIsInstance(propty, list)
+        self.assertIsInstance(propty, tuple)
         for item in propty:
             self.assertIsInstance(item, str)
         self.assertGreaterEqual(len(propty), 1)

--- a/as-ap-opticscorr/tests/tune/test_main.py
+++ b/as-ap-opticscorr/tests/tune/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-TuneCorr Soft IOC main module."""
 

--- a/as-ap-opticscorr/tests/tune/test_pvs.py
+++ b/as-ap-opticscorr/tests/tune/test_pvs.py
@@ -69,13 +69,13 @@ class TestASAPOpticsCorrTunePvs(unittest.TestCase):
     def test_get_corr_fams(self):
         """Test get_corr_fams."""
         pvs.select_ioc('SI')
-        self.assertIsInstance(pvs.get_corr_fams(), list)
+        self.assertIsInstance(pvs.get_corr_fams(), tuple)
         self.assertEqual(len(pvs.get_corr_fams()), 8)
         for fam in self.si_qfams:
             self.assertIn(fam, pvs.get_corr_fams())
 
         pvs.select_ioc('BO')
-        self.assertIsInstance(pvs.get_corr_fams(), list)
+        self.assertIsInstance(pvs.get_corr_fams(), tuple)
         self.assertEqual(len(pvs.get_corr_fams()), 2)
         for fam in self.bo_qfams:
             self.assertIn(fam, pvs.get_corr_fams())
@@ -105,7 +105,7 @@ class TestASAPOpticsCorrTunePvs(unittest.TestCase):
             self.assertTrue('CorrFactor-RB' in db)
             self.assertTrue('ConfigMA-Cmd' in db)
             self.assertTrue('Status-Mon' in db)
-            self.assertTrue('Status-Cte' in db)
+            self.assertTrue('StatusLabels-Cte' in db)
 
             for fam in qfams:
                 self.assertTrue('RefKL' + fam + '-Mon' in db)

--- a/as-ap-opticscorr/tests/tune/test_pvs.py
+++ b/as-ap-opticscorr/tests/tune/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-TuneCorr Soft IOC pvs module."""
 

--- a/as-ap-posang/as_ap_posang/pvs.py
+++ b/as-ap-posang/as_ap_posang/pvs.py
@@ -2,6 +2,7 @@
 
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy import util as _util
+from siriuspy.csdevice.posang import get_posang_database as _get_database
 
 
 _COMMIT_HASH = _util.get_last_commit_hash()
@@ -21,78 +22,28 @@ def select_ioc(transport_line):
 
 def get_pvs_section():
     """Return Soft IOC transport line."""
-    global _TL
     return _TL
 
 
 def get_pvs_vaca_prefix():
     """Return Soft IOC vaca prefix."""
-    global _PREFIX_VACA
     return _PREFIX_VACA
 
 
 def get_pvs_prefix():
     """Return Soft IOC prefix."""
-    global _PREFIX
     return _PREFIX
 
 
 def get_pvs_database():
     """Return Soft IOC database."""
-    global _COMMIT_HASH
-    pvs_database = {
-        'Version-Cte':       {'type': 'string', 'value': _COMMIT_HASH},
-
-        'Log-Mon':           {'type': 'string', 'value': 'Starting...'},
-
-        'DeltaPosX-SP':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mm', 'hilim': 5, 'lolim': -5},
-        'DeltaPosX-RB':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mm'},
-        'DeltaAngX-SP':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad', 'hilim': 4, 'lolim': -4},
-        'DeltaAngX-RB':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-
-        'DeltaPosY-SP':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mm', 'hilim': 5, 'lolim': -5},
-        'DeltaPosY-RB':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mm'},
-        'DeltaAngY-SP':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad', 'hilim': 4, 'lolim': -4},
-        'DeltaAngY-RB':      {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-
-        'ConfigName-SP':     {'type': 'string', 'value': ''},
-        'ConfigName-RB':     {'type': 'string', 'value': ''},
-        'RespMatX-Mon':      {'type': 'float', 'value': 4*[0], 'prec': 3,
-                              'count': 4},
-        'RespMatY-Mon':      {'type': 'float', 'value': 4*[0], 'prec': 3,
-                              'count': 4},
-
-        'RefKickCH1-Mon':    {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-        'RefKickCH2-Mon':    {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-        'RefKickCV1-Mon':    {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-        'RefKickCV2-Mon':    {'type': 'float', 'value': 0, 'prec': 6,
-                              'unit': 'mrad'},
-        'SetNewRefKick-Cmd': {'type': 'int', 'value': 0},
-
-        'ConfigMA-Cmd':   {'type': 'int', 'value': 0},
-
-        'Status-Mon':     {'type': 'int', 'value': 0xf},
-        'Status-Cte':     {'type': 'string', 'count': 4, 'value':
-                           ('MA Connection', 'MA PwrState',
-                            'MA OpMode', 'MA CtrlMode')},
-    }
+    pvs_database = _get_database()
+    pvs_database['Version-Cte']['value'] = _COMMIT_HASH
     return pvs_database
 
 
 def print_banner_and_save_pv_list():
     """Print Soft IOC banner."""
-    global _TL, _PREFIX, _COMMIT_HASH, _DEVICE, _PREFIX_VACA
     _util.print_ioc_banner(
         ioc_name=_TL + '-AP-PosAng',
         db=get_pvs_database(),

--- a/as-ap-posang/tests/test_main.py
+++ b/as-ap-posang/tests/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-PosAng Soft IOC main module."""
 

--- a/as-ap-posang/tests/test_pvs.py
+++ b/as-ap-posang/tests/test_pvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python-sirius
 
 """Module to test AS-AP-PosAng Soft IOC pvs module."""
 

--- a/as-ap-posang/tests/test_pvs.py
+++ b/as-ap-posang/tests/test_pvs.py
@@ -84,7 +84,7 @@ class TestASAPPosAngPvs(unittest.TestCase):
         self.assertTrue('SetNewRefKick-Cmd' in pvs.get_pvs_database())
         self.assertTrue('ConfigMA-Cmd' in pvs.get_pvs_database())
         self.assertTrue('Status-Mon' in pvs.get_pvs_database())
-        self.assertTrue('Status-Cte' in pvs.get_pvs_database())
+        self.assertTrue('StatusLabels-Cte' in pvs.get_pvs_database())
 
         # Test IOC interface: pvs units
         self.assertEqual(

--- a/as-ap-posang/tests/test_pvs.py
+++ b/as-ap-posang/tests/test_pvs.py
@@ -21,6 +21,14 @@ valid_interface = (
 class TestASAPPosAngPvs(unittest.TestCase):
     """Test AS-AP-PosAng Soft IOC."""
 
+    def setUp(self):
+        """Setup tests."""
+        csdevice_patcher = mock.patch(
+            "as_ap_posang.pvs._get_database",
+            autospec=True)
+        self.addCleanup(csdevice_patcher.stop)
+        self.mock_csdevice = csdevice_patcher.start()
+
     def test_public_interface(self):
         """Test module's public interface."""
         valid = util.check_public_interface_namespace(pvs, valid_interface,
@@ -59,58 +67,8 @@ class TestASAPPosAngPvs(unittest.TestCase):
 
     def test_get_pvs_database(self):
         """Test get_pvs_database."""
-        pvs.select_ioc('TransportLine')
-        self.assertIsInstance(pvs.get_pvs_database(), dict)
-
-        # Test IOC interface: pv names
-        self.assertTrue('Version-Cte' in pvs.get_pvs_database())
-        self.assertTrue('Log-Mon' in pvs.get_pvs_database())
-        self.assertTrue('DeltaPosX-SP' in pvs.get_pvs_database())
-        self.assertTrue('DeltaPosX-RB' in pvs.get_pvs_database())
-        self.assertTrue('DeltaAngX-SP' in pvs.get_pvs_database())
-        self.assertTrue('DeltaAngX-RB' in pvs.get_pvs_database())
-        self.assertTrue('DeltaPosY-SP' in pvs.get_pvs_database())
-        self.assertTrue('DeltaPosY-RB' in pvs.get_pvs_database())
-        self.assertTrue('DeltaAngY-SP' in pvs.get_pvs_database())
-        self.assertTrue('DeltaAngY-RB' in pvs.get_pvs_database())
-        self.assertTrue('ConfigName-SP' in pvs.get_pvs_database())
-        self.assertTrue('ConfigName-RB' in pvs.get_pvs_database())
-        self.assertTrue('RespMatX-Mon' in pvs.get_pvs_database())
-        self.assertTrue('RespMatY-Mon' in pvs.get_pvs_database())
-        self.assertTrue('RefKickCH1-Mon' in pvs.get_pvs_database())
-        self.assertTrue('RefKickCH2-Mon' in pvs.get_pvs_database())
-        self.assertTrue('RefKickCV1-Mon' in pvs.get_pvs_database())
-        self.assertTrue('RefKickCV2-Mon' in pvs.get_pvs_database())
-        self.assertTrue('SetNewRefKick-Cmd' in pvs.get_pvs_database())
-        self.assertTrue('ConfigMA-Cmd' in pvs.get_pvs_database())
-        self.assertTrue('Status-Mon' in pvs.get_pvs_database())
-        self.assertTrue('StatusLabels-Cte' in pvs.get_pvs_database())
-
-        # Test IOC interface: pvs units
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaPosX-SP']['unit'], 'mm')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaPosX-RB']['unit'], 'mm')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaAngX-SP']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaAngX-RB']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaPosY-SP']['unit'], 'mm')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaPosY-RB']['unit'], 'mm')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaAngY-SP']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['DeltaAngY-RB']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['RefKickCH1-Mon']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['RefKickCH2-Mon']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['RefKickCV1-Mon']['unit'], 'mrad')
-        self.assertEqual(
-            pvs.get_pvs_database()['RefKickCV2-Mon']['unit'], 'mrad')
+        pvs.get_pvs_database()
+        self.mock_csdevice.assert_called()
 
     @mock.patch("as_ap_posang.pvs._util")
     def test_print_banner_and_save_pv_list(self, util):


### PR DESCRIPTION
This PR migrates some databases from machine-application to siriuspy.csdevice.
It adapts `currinfo`, `opticscorr` and `posang` modules and tests to new structure.