### PR TITLE
Fix all setup.py to include access_rules.as file in the installation.

### DIFF
--- a/as-ap-currinfo/MANIFEST.in
+++ b/as-ap-currinfo/MANIFEST.in
@@ -1,0 +1,3 @@
+include as_ap_currinfo/charge/access_rules.as
+include as_ap_currinfo/current/access_rules.as
+include as_ap_currinfo/lifetime/access_rules.as

--- a/as-ap-currinfo/setup.py
+++ b/as-ap-currinfo/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_ap_currinfo'],
     package_data={'as_ap_currinfo': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-bo-ap-currinfo-current.py',
              'scripts/sirius-ioc-bo-ap-currinfo-lifetime.py',
              'scripts/sirius-ioc-si-ap-currinfo-charge.py',

--- a/as-ap-currinfo/setup.py
+++ b/as-ap-currinfo/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python-sirius
 """Package installer."""
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('VERSION', 'r') as _f:
     __version__ = _f.read().strip()
@@ -19,7 +19,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering'
     ],
-    packages=['as_ap_currinfo'],
+    packages=find_packages(),
     package_data={'as_ap_currinfo': ['VERSION']},
     include_package_data=True,
     scripts=['scripts/sirius-ioc-bo-ap-currinfo-current.py',

--- a/as-ap-opticscorr/MANIFEST.in
+++ b/as-ap-opticscorr/MANIFEST.in
@@ -1,0 +1,2 @@
+include as_ap_opticscorr/tune/access_rules.as
+include as_ap_opticscorr/chrom/access_rules.as

--- a/as-ap-opticscorr/setup.py
+++ b/as-ap-opticscorr/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python-sirius
 """Package installer."""
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('VERSION', 'r') as _f:
     __version__ = _f.read().strip()
@@ -19,8 +19,9 @@ setup(
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering'
     ],
-    packages=['as_ap_opticscorr'],
+    packages=find_packages(),
     package_data={'as_ap_opticscorr': ['VERSION'], },
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-bo-ap-tunecorr.py',
              'scripts/sirius-ioc-bo-ap-chromcorr.py',
              'scripts/sirius-ioc-si-ap-tunecorr.py',

--- a/as-ap-posang/MANIFEST.in
+++ b/as-ap-posang/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ap_posang/access_rules.as

--- a/as-ap-posang/setup.py
+++ b/as-ap-posang/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_ap_posang'],
     package_data={'as_ap_posang': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-tb-ap-posang.py',
              'scripts/sirius-ioc-ts-ap-posang.py',
              ],

--- a/as-ap-sofb/MANIFEST.in
+++ b/as-ap-sofb/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ap_sofb/access_rules.as

--- a/as-ap-sofb/setup.py
+++ b/as-ap-sofb/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_ap_sofb'],
     package_data={'as_ap_sofb': []},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-si-ap-sofb.py',
              'scripts/sirius-ioc-bo-ap-sofb.py',
              'scripts/sirius-ioc-tb-ap-sofb.py',

--- a/as-ma/MANIFEST.in
+++ b/as-ma/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ma/access_rules.as

--- a/as-ma/setup.py
+++ b/as-ma/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_ma'],
     package_data={'as_ma': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-as-pm.py',
              'scripts/sirius-ioc-as-ma.py',
              ],

--- a/as-ps/MANIFEST.in
+++ b/as-ps/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ps/access_rules.as

--- a/as-ps/setup.py
+++ b/as-ps/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_ps'],
     package_data={'as_ps': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-as-ps.py'],
     zip_safe=False
 )

--- a/as-pu/MANIFEST.in
+++ b/as-pu/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_pu/access_rules.as

--- a/as-pu/setup.py
+++ b/as-pu/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     packages=['as_pu'],
     package_data={'as_pu': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-as-pu.py', ],
     zip_safe=False
 )

--- a/as-ti-control/MANIFEST.in
+++ b/as-ti-control/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ti_control/access_rules.as

--- a/as-ti-control/setup.py
+++ b/as-ti-control/setup.py
@@ -20,6 +20,7 @@ setup(
     ],
     packages=['as_ti_control'],
     package_data={'as_ti_control': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-as-ti-control.py'],
     zip_safe=False
 )

--- a/as-ti-ll-simul/MANIFEST.in
+++ b/as-ti-ll-simul/MANIFEST.in
@@ -1,0 +1,1 @@
+include as_ti_ll_simul/access_rules.as

--- a/as-ti-ll-simul/setup.py
+++ b/as-ti-ll-simul/setup.py
@@ -20,6 +20,7 @@ setup(
     ],
     packages=['as_ti_ll_simul'],
     package_data={'as_ti_ll_simul': ['VERSION']},
+    include_package_data=True,
     scripts=['scripts/sirius-ioc-as-ti-ll-simul.py'],
     zip_safe=False
 )


### PR DESCRIPTION
This PR: fix setup.py files and include a MANIFEST.in file in all subpackages to include access_rules.as files. Also, it fixed as_ap_currinfo and as_ap_opticscorr installation.