### PR TITLE
Pr update ps ioc setpoints

### DIFF
--- a/as-ps/as_ps/main.py
+++ b/as-ps/as_ps/main.py
@@ -58,7 +58,7 @@ class App:
             for psname in bbb.psnames:
                 if 'TB' in psname:
                     if self._prucqueue is None:
-                        print('!!!!', psname)
+                        # print('!!!!', psname)
                         self._prucqueue = _PRUCQueue()
                 self._bbb_devices[psname] = bbb
 


### PR DESCRIPTION
Change how PS IOC deals with PV setpoints. First it accepts setpoints by updating its epics DB, then it queues the write request to later process. For testing, only power sypplies of TB are affected at this point.