### PR TITLE
Increase CA_MAX_ARRAY for imgproc IOCs

### DIFF
--- a/bl-ap-imgproc/scripts/sirius-ioc-bl-ap-imgproc-caxdvf1.py
+++ b/bl-ap-imgproc/scripts/sirius-ioc-bl-ap-imgproc-caxdvf1.py
@@ -4,7 +4,7 @@ import os
 import argparse as _argparse
 from bl_ap_imgproc import run
 
-os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '21000000'
+os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '26000000'
 
 DEVNAME = 'CAX:A:BASLER01'
 

--- a/bl-ap-imgproc/scripts/sirius-ioc-bl-ap-imgproc-caxdvf2.py
+++ b/bl-ap-imgproc/scripts/sirius-ioc-bl-ap-imgproc-caxdvf2.py
@@ -4,7 +4,7 @@ import os
 import argparse as _argparse
 from bl_ap_imgproc import run
 
-os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '21000000'
+os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '26000000'
 
 DEVNAME = 'CAX:B:BASLER01'
 


### PR DESCRIPTION
Tests showed that new IOC + new basler config, this is needed for all cam setups.