### PR TITLE
Fix SOFB Initialization

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 # @liulin-lili
 
 # --- default owners of the repo
-* @xresende @anacso17 @fernandohds564 @murilobalves
+* @xresende @anacso17 @fernandohds564
 
 
 # -------- BASIC MODULES --------
@@ -19,25 +19,25 @@
 # -------- SUBPACKAGES --------
 
 # --- as-ap-currinfo
-/as-ap-currinfo/ @anacso17 @murilobalves
+/as-ap-currinfo/ @anacso17
 
 # --- as-ap-opmode
 /as-ap-opmode/ @xresende @anacso17
 
 # --- as-ap-opticscorr
-/as-ap-opticscorr/ @anacso17 @fernandohds564 @xresende @murilobalves
+/as-ap-opticscorr/ @anacso17 @fernandohds564 @xresende
 
 # --- as-ap-posang
-/as-ap-posang/ @anacso17 @fernandohds564 @xresende @murilobalves
+/as-ap-posang/ @anacso17 @fernandohds564 @xresende
 
 # --- as-ma
-/as-ma/ @xresende @anacso17 @murilobalves
+/as-ma/ @xresende @anacso17
 
 # --- as-ps
-/as-ps/ @xresende @anacso17 @murilobalves
+/as-ps/ @xresende @anacso17
 
 # --- as-ti-control
 /as-ti-control/ @fernandohds564 @xresende @anacso17
 
 # --- as-ap-sofb
-/as-ap-sofb/ @fernandohds564  @xresende @anacso17 @murilobalves
+/as-ap-sofb/ @fernandohds564 @xresende @anacso17

--- a/as-ap-sofb/as_ap_sofb/as_ap_sofb.py
+++ b/as-ap-sofb/as_ap_sofb/as_ap_sofb.py
@@ -141,7 +141,7 @@ def run(acc='SI', debug=False, tests=False):
 
     # initiate a new thread responsible for listening for client connections
     server_thread = _pcaspy_tools.ServerThread(server)
-    server_thread.setDaemon(True)
+    server_thread.daemon = True
     _log.info('Starting Server Thread.')
     server_thread.start()
 
@@ -152,6 +152,12 @@ def run(acc='SI', debug=False, tests=False):
     app.matrix = _EpicsMatrix(
         acc=app.acc, prefix=app.prefix, callback=driver.update_pv)
 
+    _log.info('Waiting for PVs to connect.')
+    app.wait_for_connection(timeout=20)
+    _log.info('All PVs connected.')
+    _log.info('Configuring Orbit Mode.')
+    app.orbit.set_orbit_mode(app.orbit.mode)
+    _log.info('Done')
     # main loop
     while not stop_event:
         app.process()


### PR DESCRIPTION
Make sure BPMs are properly configured at initialization.

Depends on lnls-sirius/dev-packages#1178.

This commit forces the configuration of the proper SOFBmode-Sts to the BPMs and timing system.

This breaks our convention of not setting any PVs during initialization, but I think it is worth it, because nowadays TL SOFBs generally initialize in a broken state and operators forget/don't notice they have to reconfigure the acquisitions, which makes the IOC fail to get new trajectories.

I also removed @murilobalves from CODEOWNERS. See discution in lnls-sirius/dev-packages#1178.